### PR TITLE
<Popover>

### DIFF
--- a/components/Popover/Popover.stories.tsx
+++ b/components/Popover/Popover.stories.tsx
@@ -1,0 +1,234 @@
+import * as React from "react";
+import styled from "styled-components";
+import Popover, { PopoverTrigger, PopoverPlacement } from "./Popover";
+import { number, select, boolean } from "@storybook/addon-knobs";
+import PopoverControlContext from "./PopoverControlContext";
+import { action } from "@storybook/addon-actions";
+
+export default {
+  title: "Popover",
+  component: Popover,
+};
+
+export const example = () => (
+  <div style={{ padding: 128 }}>
+    <Popover
+      placement={select("placement", PLACEMENTS, PopoverPlacement.top)}
+      distance={number("distance", 8)}
+      skidding={number("skidding", 0)}
+      trigger={select("trigger", TRIGGERS, undefined)}
+      stickyMainAxis={boolean("stickyMainAxis", true)}
+      stickyCrossAxis={boolean("stickyCrossAxis", false)}
+      animationDuration={number("animationDuration", 200)}
+      hidden={boolean("hidden", false)}
+      onShow={action("onShow")}
+      onHide={action("onHide")}
+      render={(isShown) => (
+        <PopoverContent
+          _shown={isShown}
+          animationDuration={number("animationDuration", 200)}
+        >
+          Popover content shows alongside the target
+        </PopoverContent>
+      )}
+    >
+      <span>This is Popover target</span>
+    </Popover>
+  </div>
+);
+
+export const distanceAndSkidding = () => (
+  <div style={{ padding: 128 }}>
+    <Popover
+      distance={32}
+      render={(isShown) => (
+        <PopoverContent _shown={isShown}>
+          Popover content shows 32px distance from the target
+        </PopoverContent>
+      )}
+    >
+      <span>This is Popover target</span>
+    </Popover>
+  </div>
+);
+
+export const showWhileHover = () => (
+  <div style={{ padding: 128 }}>
+    <Popover
+      trigger={PopoverTrigger.mouseenter}
+      render={(isShown) => (
+        <PopoverContent _shown={isShown}>Ta-da!</PopoverContent>
+      )}
+    >
+      <span>Hover on me to show</span>
+    </Popover>
+  </div>
+);
+
+export const showOnClick = () => (
+  <div style={{ padding: 128 }}>
+    <Popover
+      trigger={PopoverTrigger.click}
+      render={(isShown) => (
+        <PopoverContent _shown={isShown}>How can I help you?</PopoverContent>
+      )}
+    >
+      <span>Click me to show</span>
+    </Popover>
+  </div>
+);
+
+export const sticky = () => {
+  const outerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    outerRef.current!.scrollTo(768, 768);
+  });
+
+  return (
+    <div
+      style={{
+        width: 512,
+        height: 512,
+        border: "1px #ccc solid",
+        overflow: "scroll",
+      }}
+      ref={outerRef}
+    >
+      <div
+        style={{
+          display: "flex",
+          width: 2048,
+          height: 2048,
+          placeContent: "center",
+          placeItems: "center",
+        }}
+      >
+        <Popover
+          stickyBoundaryRef={outerRef}
+          render={(isShown) => (
+            <PopoverContent _shown={isShown}>
+              You can scroll the view
+              <br />
+              but this content sticks not to hide
+            </PopoverContent>
+          )}
+        >
+          <span>Trigger Element</span>
+        </Popover>
+      </div>
+    </div>
+  );
+};
+
+export const controlled = () => {
+  const [isPopoverShown, setPopoverShown] = React.useState(true);
+
+  return (
+    <div style={{ padding: 128 }}>
+      <Popover
+        render={(isShown) => (
+          <PopoverContent _shown={isShown}>
+            This popover is controlled by another element
+          </PopoverContent>
+        )}
+        hidden={!isPopoverShown}
+      >
+        <span>Popover target</span>
+      </Popover>
+
+      <div style={{ marginTop: 64 }}>
+        <button onClick={() => setPopoverShown(!isPopoverShown)}>
+          Toggle Popover
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export const controlInContent = () => {
+  return (
+    <div style={{ padding: 128 }}>
+      <Popover
+        trigger={PopoverTrigger.mouseenter}
+        render={(isShown) => (
+          <PopoverContent _shown={isShown}>
+            <p>Clicking popover content happens nothing, but</p>
+
+            <p>
+              <PopoverControlContext.Consumer>
+                {({ hide }) => (
+                  <button onClick={hide}>
+                    This button closes this popover
+                  </button>
+                )}
+              </PopoverControlContext.Consumer>
+            </p>
+          </PopoverContent>
+        )}
+      >
+        <span>Hover on me to show</span>
+      </Popover>
+    </div>
+  );
+};
+
+export const customAnimationDuration = () => (
+  <div style={{ padding: 128 }}>
+    <Popover
+      trigger={PopoverTrigger.mouseenter}
+      animationDuration={1500}
+      render={(isShown) => (
+        <PopoverContentLongTransition _shown={isShown}>
+          This popover shows in 1500ms (verrry slowly)
+        </PopoverContentLongTransition>
+      )}
+    >
+      <span>Hover on me to show</span>
+    </Popover>
+  </div>
+);
+
+const PLACEMENTS = {
+  "PopoverPlacment.auto": PopoverPlacement.auto,
+  "PopoverPlacment.start": PopoverPlacement.start,
+  "PopoverPlacment.end": PopoverPlacement.end,
+  "PopoverPlacment.top": PopoverPlacement.top,
+  "PopoverPlacment.bottom": PopoverPlacement.bottom,
+  "PopoverPlacment.right": PopoverPlacement.right,
+  "PopoverPlacment.left": PopoverPlacement.left,
+  "PopoverPlacment.topStart": PopoverPlacement.topStart,
+  "PopoverPlacment.topEnd": PopoverPlacement.topEnd,
+  "PopoverPlacment.bottomStart": PopoverPlacement.bottomStart,
+  "PopoverPlacment.bottomEnd": PopoverPlacement.bottomEnd,
+  "PopoverPlacment.rightStart": PopoverPlacement.rightStart,
+  "PopoverPlacment.rightEnd": PopoverPlacement.rightEnd,
+  "PopoverPlacment.leftStart": PopoverPlacement.leftStart,
+  "PopoverPlacment.leftEnd": PopoverPlacement.leftEnd,
+};
+
+const TRIGGERS = {
+  "none (not set)": undefined,
+  "PopoverTrigger.click": PopoverTrigger.click,
+  "PopoverTrigger.mouseenter": PopoverTrigger.mouseenter,
+};
+
+const PopoverContent = styled.div<{
+  _shown: boolean;
+  animationDuration?: number;
+}>`
+  padding: 16px;
+  background-color: white;
+  border-radius: 4px;
+  box-shadow: 0px 0px 12px #222f3e1f, 0px 12px 24px #222f3e0f;
+  transform: ${({ _shown }) =>
+    _shown ? "translateY(0) scale(1)" : "translateY(-8px) scale(0.95)"};
+  opacity: ${({ _shown }) => (_shown ? "1" : "0")};
+  transition-property: opacity, transform;
+  transition-duration: ${({ animationDuration }) => animationDuration ?? 200}ms;
+  transition-timing-function: ease-in-out;
+`;
+
+const PopoverContentLongTransition = styled(PopoverContent)`
+  transition-duration: 1500ms;
+`;

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -1,0 +1,176 @@
+import Tippy from "@tippyjs/react/headless";
+import * as React from "react";
+import { Instance as TippyInstance } from "tippy.js";
+import PopoverrControlContext from "./PopoverControlContext";
+
+interface Props extends React.Attributes {
+  placement?: PopoverPlacement;
+  /** The main axis distance for the content from the trigger element */
+  distance?: number;
+  /** The cross axis distance for the content from the trigger element */
+  skidding?: number;
+  /** The trigger to show the content. Non-set permanently shows the content */
+  trigger?: PopoverTrigger;
+  /**   */
+  stickyMainAxis?: boolean;
+  stickyCrossAxis?: boolean;
+  stickyBoundaryRef?: React.RefObject<any>;
+  animationDuration?: number;
+  hidden?: boolean;
+  onShow?: () => void;
+  onHide?: () => void;
+  /** The items show inside. Preferred to use `<PopoverrMenuItem>` */
+  render: (isShown: boolean) => React.ReactNode;
+  children: React.ReactElement<React.RefAttributes<any>>;
+}
+
+export interface PopoverElement {
+  show: () => void;
+  hide: () => void;
+}
+
+export enum PopoverTrigger {
+  mouseenter = "mouseenter",
+  click = "click",
+}
+
+export enum PopoverPlacement {
+  auto = "auto",
+  start = "auto-start",
+  end = "auto-end",
+  top = "top",
+  bottom = "bottom",
+  right = "right",
+  left = "left",
+  topStart = "top-start",
+  topEnd = "top-end",
+  bottomStart = "bottom-start",
+  bottomEnd = "bottom-end",
+  rightStart = "right-start",
+  rightEnd = "right-end",
+  leftStart = "left-start",
+  leftEnd = "left-end",
+}
+
+/**
+ * Low-level popover control abstract component
+ */
+export default function Popover({
+  placement = PopoverPlacement.top,
+  distance = 8,
+  skidding = 0,
+  trigger,
+  stickyMainAxis = true,
+  stickyCrossAxis = true,
+  stickyBoundaryRef,
+  animationDuration = 200,
+  hidden = false,
+  onShow = () => {},
+  onHide = () => {},
+  render,
+  children,
+}: Props) {
+  const [tippy, setTippy] = React.useState<TippyInstance | null>(null);
+  const [hideTimeoutId, setHideTimeoutId] = React.useState<number | void>(0);
+  const [isShown, setShown] = React.useState(!trigger);
+
+  const show = React.useCallback(() => tippy?.show(), [tippy]);
+  const hide = React.useCallback(() => tippy?.hide(), [tippy]);
+
+  const onCreate = React.useCallback((tippy: TippyInstance) => {
+    setTippy(tippy);
+  }, []);
+
+  const onDestroy = React.useCallback((tippy: TippyInstance) => {
+    tippy.unmount();
+
+    setTippy(null);
+  }, []);
+
+  const _onShow = React.useCallback(
+    (_: TippyInstance) => {
+      if (hideTimeoutId) {
+        clearTimeout(hideTimeoutId);
+      }
+
+      requestAnimationFrame(() => {
+        setShown(true);
+        onShow();
+      });
+    },
+    [hideTimeoutId]
+  );
+
+  const _onHide = React.useCallback(
+    (_: TippyInstance) => {
+      if (hideTimeoutId) {
+        clearTimeout(hideTimeoutId);
+      }
+
+      setHideTimeoutId(
+        setTimeout(() => {
+          setHideTimeoutId(undefined);
+          tippy?.unmount();
+        }, animationDuration)
+      );
+
+      setShown(false);
+      onHide();
+    },
+    [tippy, hideTimeoutId, animationDuration]
+  );
+
+  React.useEffect(() => {
+    if (!trigger && !hidden) {
+      show();
+    } else {
+      hide();
+    }
+  }, [trigger, hidden, show, hide]);
+
+  return (
+    <Tippy
+      animation
+      interactive
+      placement={placement}
+      trigger={trigger}
+      visible={trigger ? undefined : isShown}
+      render={(_) => (
+        <PopoverrControlContext.Provider value={{ hide }}>
+          {render(isShown)}
+        </PopoverrControlContext.Provider>
+      )}
+      popperOptions={{
+        modifiers: [
+          {
+            name: "offset",
+            options: {
+              offset: [skidding, distance],
+            },
+          },
+          {
+            name: "preventOverflow",
+            options: {
+              mainAxis: stickyMainAxis,
+              altAxis: stickyCrossAxis,
+              boundary: stickyBoundaryRef
+                ? stickyBoundaryRef.current!
+                : "clippingParents",
+              tether: false,
+            },
+          },
+        ],
+      }}
+      onCreate={onCreate}
+      onDestroy={onDestroy}
+      onShow={_onShow}
+      onHide={_onHide}
+      // WORKAROUND: onClickOutside is not defined in d.ts yet
+      {...{
+        onClickOutside: trigger === PopoverTrigger.click ? hide : () => {},
+      }}
+    >
+      {children}
+    </Tippy>
+  );
+}

--- a/components/Popover/PopoverControlContext.ts
+++ b/components/Popover/PopoverControlContext.ts
@@ -1,0 +1,7 @@
+import * as React from "react";
+
+interface PopoverControl {
+  hide: () => void;
+}
+
+export default React.createContext<PopoverControl>(null as any);

--- a/components/Popover/index.ts
+++ b/components/Popover/index.ts
@@ -1,0 +1,3 @@
+export { default, PopoverPlacement, PopoverTrigger } from "./Popover";
+export type { PopoverElement } from "./Popover";
+export { default as PopoverControlContext } from "./PopoverControlContext";


### PR DESCRIPTION
Blocker: ~~#159~~ 

`<Popover>` is an abstract component that shows an element node alongside another element node.

`<PopoverMenu>`'s implementation will be replaced with using `<Popover>`.

Working example: https://deploy-preview-158--csof.netlify.com/?path=/story/popover--example

<img width="1569" alt="Screen Shot 2020-04-04 at 6 14 58 PM" src="https://user-images.githubusercontent.com/4289883/78464603-34bf0400-76a0-11ea-90bb-7aa4a50a6c47.png">
