### PR TITLE
Change TypeScript's compiling target to es2018

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2018",
     "module": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "jsx": "preserve",


### PR DESCRIPTION
So far we use both of TypeScript and Babel for Next.js and Storybook. TypeScript doesn't transform new syntaxes `??` and `.?` because of `target : "esnext"` setting, but Babel runs as the next transformer of the pipeline. Babel should transform those syntaxes because it includes typescript plugin, but it doesn't support new features yet.

Here's a change that TypeScript deals with those syntaxes and pass transpiled code to Babel.